### PR TITLE
URI Connection Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+# Change these settings to your own preference
+indent_style = tabs
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ npm run test
 ```js
 var seneca = require('seneca')()
 seneca.use('mongo-store', {
-  name: 'dbname',
-  host: '127.0.0.1',
-  port: 27017
+  uri: 'mongodb://120.0.0.1:27017/dbname'
 })
 
 seneca.ready(function(){
@@ -44,6 +42,28 @@ seneca.ready(function(){
   })
 })
 ```
+
+## Connection Options
+
+You can connection to MongoDB a few different ways.
+
+```js
+// Standard URI pattern which gets passed directly to the native MongoDB .connect() method
+seneca.use('mongo-store', {
+  uri: 'mongodb://120.0.0.1:27017/dbname',
+  options: {}
+})
+
+// Key based connection gets transformed into a mongodb:// URI
+seneca.use('mongo-store', {
+  db: 'dbname',
+  host: '127.0.0.1',
+  port: 27017,
+  options: {}
+})
+```
+
+The `options` also gets passed into the MongoDB .connect() method. Refer to the [Connection Settings](http://mongodb.github.io/node-mongodb-native/2.0/reference/connecting/connection-settings/) documentation for a list of those options.
 
 ## Usage
 You don't use this module directly. It provides an underlying data storage engine for the Seneca

--- a/mongo-store.js
+++ b/mongo-store.js
@@ -4,6 +4,7 @@
 
 var _     = require('lodash')
 var mongo = require('mongodb')
+var MongoClient = mongo.MongoClient
 var ObjectID = mongo.ObjectID
 
 var name = "mongo-store"
@@ -107,84 +108,42 @@ module.exports = function(opts) {
 
 
 
-  function configure(spec,cb) {
-    specifications = spec
+  function configure(conf,cb) {
     // defer connection
     // TODO: expose connection action
-    if( !_.isUndefined(spec.connect) && !spec.connect ) {
+    if( !_.isUndefined(conf.connect) && !conf.connect ) {
       return cb()
     }
 
-
-    var conf = 'string' == typeof(spec) ? null : spec
-
-    if( !conf ) {
-      conf = {}
-      var urlM = /^mongo:\/\/((.*?):(.*?)@)?(.*?)(:?(\d+))?\/(.*?)$/.exec(spec);
-      conf.name   = urlM[7]
-      conf.port   = urlM[6]
-      conf.server = urlM[4]
-      conf.username = urlM[2]
-      conf.password = urlM[3]
-
-      conf.port = conf.port ? parseInt(conf.port,10) : null
+    // Turn the hash into a mongo uri
+    if (!conf.uri) {
+      conf.uri = 'mongodb://';
+      conf.uri += (conf.username) ? conf.username : '';
+      conf.uri += (conf.password) ? ':' + conf.password + '@' : '';
+      conf.uri += conf.host || conf.server;
+      conf.uri += (conf.port) ? ':' + conf.port : '';
+      conf.uri += '/' + opts.db || opts.name;
     }
 
-
-    conf.host = conf.host || conf.server
-    conf.username = conf.username || conf.user
-    conf.password = conf.password || conf.pass
-
-
+    // Extend the db options with some defaults
+    // See http://mongodb.github.io/node-mongodb-native/2.0/reference/connecting/connection-settings/ for options
     var dbopts = seneca.util.deepextend({
       native_parser:false,
       auto_reconnect:true,
       w:1
-    },conf.options)
+    }, conf.options)
 
-
-    if( conf.replicaset ) {
-      var rservs = []
-      for( var i = 0; i < conf.replicaset.servers.length; i++ ) {
-	var servconf = conf.replicaset.servers[i]
-	rservs.push(new mongo.Server(servconf.host,servconf.port,dbopts))
-      }
-      var rset = new mongo.ReplSet(rservs)
-      dbinst = new mongo.Db( conf.name, rset, dbopts )
-    }
-    else {
-      dbinst = new mongo.Db(
-        conf.name,
-        new mongo.Server(
-          conf.host || conf.server,
-          conf.port || mongo.Connection.DEFAULT_PORT,
-          {}
-        ),
-        dbopts
-      )
-    }
-
-    dbinst.open(function(err){
-      if( err ) {
-        return seneca.die('open',err,conf);
+    // Connect using the URI
+    MongoClient.connect(conf.uri, dbopts, function(err, db) {
+      if (err) {
+        return seneca.die('connect', err, conf);
       }
 
-      if( conf.username ) {
-        dbinst.authenticate(conf.username,conf.password,function(err){
-          if( err) {
-            seneca.log.error('init','db auth failed for '+conf.username,dbopts)
-            return cb(err);
-          }
-
-          seneca.log.debug('init','db open and authed for '+conf.username,dbopts)
-          cb(null)
-        })
-      }
-      else {
-        seneca.log.debug('init','db open',dbopts)
-        cb(null)
-      }
-    })
+      // Set the instance to use throughout the plugin
+      dbinst = db;
+      seneca.log.debug('init', 'db open', conf);
+      cb(null);
+    });
   }
 
 

--- a/test/mongo.test.js
+++ b/test/mongo.test.js
@@ -15,9 +15,7 @@ var shared = require('seneca-store-test')
 
 var si = seneca()
 si.use(require('..'),{
-  name:'senecatest',
-  host:'127.0.0.1',
-  port:27017,
+  uri: 'mongodb://127.0.0.1/senecatest',
   options:{
     // uncomment to test
     // native_parser:true


### PR DESCRIPTION
Now use `.connect` along with URI strings for connecting and passing options to native MongoDB driver.